### PR TITLE
Fix deadmin

### DIFF
--- a/src/segments/_global.lua
+++ b/src/segments/_global.lua
@@ -742,7 +742,7 @@ _S.global = {
                     end
                 end
             },
-            deadmin={rank=RANKS.ROOM_OWNER,fnc=function(player,...) _S.global.callbacks.chatCommand.lock.fnc(player,...) end},
+            deadmin={rank=RANKS.ROOM_OWNER,fnc=function(player,...) _S.global.callbacks.chatCommand.unadmin.fnc(player,...) end},
             lock={
                 rank=RANKS.ROOM_ADMIN,
                 fnc=function(player,num)

--- a/utility.lua
+++ b/utility.lua
@@ -2905,7 +2905,7 @@ _S.global = {
                     end
                 end
             },
-            deadmin={rank=RANKS.ROOM_OWNER,fnc=function(player,...) _S.global.callbacks.chatCommand.lock.fnc(player,...) end},
+            deadmin={rank=RANKS.ROOM_OWNER,fnc=function(player,...) _S.global.callbacks.chatCommand.unadmin.fnc(player,...) end},
             lock={
                 rank=RANKS.ROOM_ADMIN,
                 fnc=function(player,num)


### PR DESCRIPTION
The `!deadmin` command was an alias for `!lock` instead of `!unadmin`.

This changes it to be an alias for `!unadmin`.
I edited utility.lua by hand because it doesnt match the source in `src`.