### PR TITLE
Opti eventnewplayer

### DIFF
--- a/src/lib/segments.lua
+++ b/src/lib/segments.lua
@@ -18,7 +18,9 @@ function activateSegment(name,segment)
         s.onEnable(players[name])
     end
     players[name].activeSegments[segment]=true
-    _S.global.showMenu(name)
+    if s.menu then
+        _S.global.showMenu(name)
+    end
 end
 
 function deactivateSegment(name,segment)
@@ -54,7 +56,9 @@ function deactivateSegment(name,segment)
         s.onDisable(players[name])
     end
     players[name].activeSegments[segment]=nil
-    _S.global.showMenu(name)
+    if s.menu then
+        _S.global.showMenu(name)
+    end
 end
 
 function bindChatCommands()

--- a/src/segments/_global.lua
+++ b/src/segments/_global.lua
@@ -42,9 +42,6 @@ _S.global = {
         newGame=function()
             _S.global.tempMapName=nil
         end,
-        newPlayer=function(player)
-            _S.global.showMenu(player.name)
-        end,
         playerLeft=function(player)
             for n,p in pairs(players) do
                 if p.selected[player.name] then

--- a/utility.lua
+++ b/utility.lua
@@ -2205,9 +2205,6 @@ _S.global = {
         newGame=function()
             _S.global.tempMapName=nil
         end,
-        newPlayer=function(player)
-            _S.global.showMenu(player.name)
-        end,
         playerLeft=function(player)
             for n,p in pairs(players) do
                 if p.selected[player.name] then

--- a/utility.lua
+++ b/utility.lua
@@ -1598,7 +1598,9 @@ function activateSegment(name,segment)
         s.onEnable(players[name])
     end
     players[name].activeSegments[segment]=true
-    _S.global.showMenu(name)
+    if s.menu then
+        _S.global.showMenu(name)
+    end
 end
 
 function deactivateSegment(name,segment)
@@ -1634,7 +1636,9 @@ function deactivateSegment(name,segment)
         s.onDisable(players[name])
     end
     players[name].activeSegments[segment]=nil
-    _S.global.showMenu(name)
+    if s.menu then
+        _S.global.showMenu(name)
+    end
 end
 
 function bindChatCommands()


### PR DESCRIPTION
Changes:
 - The global segment had a callback for newPlayer calling `_S.global.showMenu`. This is unnecessary because it is going to be called by `activateSegment` anyway. Removed this callback.
 - The function `activateSegment` was calling `_S.global.showMenu` for every activated segments, even the ones that does not have a menu. This caused the function to be called 7 times from `eventNewPlayer`, running the exact same code every time. Made `activateSegment` call `showMenu` only if the segment have a menu.

This is a performance comparison of `eventNewPlayer` and some parts of it for those changes.
`newPlayer activateSegments` correspond to segment activation from eventNewPlayer.
Before:
> eventNewPlayer: 518ms / 180calls == 2.877777 ms/call
> newPlayer activateSegments: 348ms / 181calls == 1.922651 ms/call
> newPlayer addImages: 2ms / 181calls == 0.011049 ms/call
> newPlayer defaultPlayer: 46ms / 181calls == 0.254143 ms/call
> newPlayer joinedRoomMessage: 1ms / 181calls == 0.005524 ms/call
> newPlayer notifyListeners: 100ms / 181calls == 0.552486 ms/call

After:
> eventNewPlayer: 234ms / 180calls == 1.3 ms/call
> newPlayer activateSegments: 90ms / 181calls == 0.497237 ms/call
> newPlayer addImages: 3ms / 181calls == 0.016574 ms/call
> newPlayer defaultPlayer: 38ms / 181calls == 0.209944 ms/call
> newPlayer joinedRoomMessage: 2ms / 181calls == 0.011049 ms/call
> newPlayer notifyListeners: 64ms / 181calls == 0.353591 ms/call

This is measurements taken one after another, but sometime (depending on days or other parameters), eventNewPlayer can take up to 4ms of runtime.

I suggest those changes because I have observed the script crashing in funcorps, especially when many players were joining simultaneously. Especially when changing room, players are following and will all join simultaneously. This may mitigate the problem.