### PR TITLE
fixed string arguments passed to conj causing a crash

### DIFF
--- a/src/segments/_global.lua
+++ b/src/segments/_global.lua
@@ -350,7 +350,11 @@ _S.global = {
                 fnc=function(player,...)
                     local arg={...}
                     executeCommand(player,function(target,time)
-                        players[target].conjTime=time or 10
+                        if time ~= nil and not tonumber(time) then
+                            tfm.exec.chatMessage(translate("invalidargument",player.lang),player.name)
+                            return
+                        end
+                        players[target].conjTime=tonumber(time) or 10
                         toggleSegment(target, "conj", not arg[1] and not players[target].activeSegments.conj or arg[1] and true)
                     end,arg)
                 end

--- a/utility.lua
+++ b/utility.lua
@@ -2513,7 +2513,11 @@ _S.global = {
                 fnc=function(player,...)
                     local arg={...}
                     executeCommand(player,function(target,time)
-                        players[target].conjTime=time or 10
+                        if time ~= nil and not tonumber(time) then
+                            tfm.exec.chatMessage(translate("invalidargument",player.lang),player.name)
+                            return
+                        end
+                        players[target].conjTime=tonumber(time) or 10
                         toggleSegment(target, "conj", not arg[1] and not players[target].activeSegments.conj or arg[1] and true)
                     end,arg)
                 end


### PR DESCRIPTION
Changes:
 - The `!conj` command now displays an invalid argument message when being passed a string and abort.

Using `!conj sometextinsteadofnumber` causes a crash on next click.
This is due to `player.conjTime` being set to a string before this line is executed:
```lua
tfm.exec.addConjuration(x/10,y/10,player.conjTime*1000)
```